### PR TITLE
Fix issue when import multiple products combinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 - **Requires at least:** 1.6
 - **Tested up to:** 1.7.8
-- **Requires PHP:** 5.5
+- **Requires PHP:** 7.4
 - **Stable tag:** 3.4.3
 - **License:** Apache-2.0
 - **License URI:** http://www.apache.org/licenses/LICENSE-2.0

--- a/classes/models/LengowOrderDetail.php
+++ b/classes/models/LengowOrderDetail.php
@@ -34,9 +34,20 @@ class LengowOrderDetail extends OrderDetail
      */
     public static function findByOrderIdProductId($idOrder, $idProduct)
     {
-        $sql = 'SELECT id_order_detail FROM `' . _DB_PREFIX_ . 'order_detail`
-            WHERE product_id = ' . (int) $idProduct . ' AND id_order = ' . $idOrder;
-        $row = Db::getInstance()->getRow($sql);
-        return (int) $row['id_order_detail'];
+        $whereArr = [
+            '`id_order`=' . (int)$idOrder,
+            '`product_id`=' . (int)$idProduct
+        ];
+
+        $ids = explode('_', (string)$idProduct);
+
+        if (isset($ids[1])) {
+            $productAttributeId = (int)$ids[1];
+            $whereArr[] = '`product_attribute_id`=' . $productAttributeId;
+        }
+
+        $sql = 'SELECT `id_order_detail` FROM `' . _DB_PREFIX_ . 'order_detail` WHERE ' . implode(' AND ', $whereArr);
+
+        return (int)Db::getInstance()->getValue($sql);
     }
 }


### PR DESCRIPTION
**Description :**

When you import amazon commands in prestashop, if you have multiple products with multiple combinations, the lengow module not save the right "id_order_detail".

In "ps_lengow_order_line" mysql table, "id_order_detail" value is always the same for prestashop order.


**How to test :**
 - import amazon order with multiple products with multiple combinations to prestashop.
 - check a column "id_order_detail" in "ps_lengow_order_line" mysql table.