### PR TITLE
fix(marketplaces): [PCMT-738] fix condition where id could be 0

### DIFF
--- a/classes/models/LengowMarketplace.php
+++ b/classes/models/LengowMarketplace.php
@@ -676,7 +676,7 @@ class LengowMarketplace
                     }
                 }
                 $idMarketplace = self::getIdMarketplace($marketplaceName);
-                if ($idMarketplace) {
+                if (false !== $idMarketplace) {
                     self::updateMarketplace($idMarketplace, $marketplace->name, $carrierRequired);
                 } else {
                     self::insertMarketplace($marketplaceName, $marketplace->name, $carrierRequired);


### PR DESCRIPTION
This should not happen, however, 0 is still possible as a valid ID and results in creating the marketplace over and over again.