### PR TITLE
fix(shipping): only send carrier_name when carrier is Other (Amazon)

### DIFF
--- a/classes/models/LengowMarketplace.php
+++ b/classes/models/LengowMarketplace.php
@@ -494,7 +494,6 @@ class LengowMarketplace
                     $params[$arg] = $returnTrackingNumber;
                     break;
                 case LengowAction::ARG_CARRIER:
-                case LengowAction::ARG_CARRIER_NAME:
                 case LengowAction::ARG_CUSTOM_CARRIER:
                     if ((string) $lengowOrder->lengowCarrier !== '') {
                         $carrierName = (string) $lengowOrder->lengowCarrier;
@@ -514,6 +513,32 @@ class LengowMarketplace
                         );
                     }
                     $params[$arg] = $carrierName;
+                    break;
+                case LengowAction::ARG_CARRIER_NAME:
+                    // carrier_name should only be sent when carrier code is "Other"
+                    // otherwise marketplaces like Amazon reject the feed
+                    if ((string) $lengowOrder->lengowCarrier !== '') {
+                        $resolvedCarrier = (string) $lengowOrder->lengowCarrier;
+                    } else {
+                        if (!isset($deliveryAddress->id_country) || (int) $deliveryAddress->id_country === 0) {
+                            break;
+                        }
+                        $idMarketplace = self::getIdMarketplace($lengowOrder->lengowMarketplaceName);
+                        $resolvedCarrier = LengowCarrier::getCarrierMarketplaceCode(
+                            (int) $deliveryAddress->id_country,
+                            $idMarketplace,
+                            (int) $lengowOrder->id_carrier
+                        );
+                    }
+                    if (strtolower($resolvedCarrier) === 'other') {
+                        // when carrier is "Other", send the PrestaShop carrier name
+                        $idActiveCarrier = LengowCarrier::getIdActiveCarrierByIdCarrier(
+                            (int) $lengowOrder->id_carrier,
+                            (int) $deliveryAddress->id_country
+                        );
+                        $psCarrier = new Carrier($idActiveCarrier ?: (int) $lengowOrder->id_carrier);
+                        $params[$arg] = $psCarrier->name;
+                    }
                     break;
                 case LengowAction::ARG_SHIPPING_METHOD:
                     // Only send shipping_method when it is a required argument,


### PR DESCRIPTION
## Summary
- **carrier_name** was always populated with the same value as **carrier** (e.g. `carrier: "DB-SCHENKER"`, `carrier_name: "DB-SCHENKER"`), causing Amazon to reject the ship action XML feed.
- Per Amazon spec, `carrier_name` is a conditional field (`depends_on: carrier == "Other"`) and must only be sent when the carrier code is `"Other"`.
- Separated `ARG_CARRIER_NAME` handling: it is now only populated when the resolved carrier code is `"Other"`, using the PrestaShop carrier name as the free value.

## Test plan
- [ ] Ship an Amazon order with a known carrier code (e.g. DPD, DB-SCHENKER) → `carrier_name` should **not** be sent
- [ ] Ship an Amazon order with carrier code "Other" → `carrier_name` should be sent with the PrestaShop carrier name
- [ ] Verify no regression on other marketplaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)