### PR TITLE
fix(import): add company fallback from billing to shipping address

### DIFF
--- a/classes/models/LengowImportOrder.php
+++ b/classes/models/LengowImportOrder.php
@@ -1285,6 +1285,11 @@ class LengowImportOrder
             $this->shippingAddress->vat_number = $billingAddress->vat_number;
             $this->shippingAddress->update();
         }
+        // get company from billing address if empty in shipping address
+        if (empty($this->shippingAddress->company) && !empty($billingAddress->company)) {
+            $this->shippingAddress->company = $billingAddress->company;
+            $this->shippingAddress->update();
+        }
         $cartData['id_address_delivery'] = $this->shippingAddress->id;
         // get currency
         $cartData['id_currency'] = (int) Currency::getIdByIsoCode((string) $this->orderData->currency->iso_a3);


### PR DESCRIPTION
## Summary
- When importing Amazon B2B orders, the delivery address may have `company: null` while the billing address has the company populated
- This adds a fallback that copies `company` from billing to shipping address when shipping company is empty
- Follows the exact same pattern already used for `phone`, `phone_mobile`, and `vat_number` fallbacks (lines 1274-1287)

## Context
- Account ID: 16368 / Feed ID: 97321 / Marketplace: amazon_de
- Example order: 304-6147408-3811551 (`is_business: true`)
- Delivery payload: `company: null`, `first_name: null`, `last_name: null`, `full_name: "MANFRED BUECKER"`
- Billing payload: `company: "Manfred Buecker"`, `full_name: "MANFRED BUECKER"`

**Note:** The `first_name`/`last_name` missing case is already handled by existing fallback logic in `LengowAddress::validateEmptyLengow()` which parses `full_name` automatically.

## Changes
**File:** `classes/models/LengowImportOrder.php`

Added after the existing VAT number fallback (line 1287):
```php
// get company from billing address if empty in shipping address
if (empty($this->shippingAddress->company) && !empty($billingAddress->company)) {
    $this->shippingAddress->company = $billingAddress->company;
    $this->shippingAddress->update();
}
```

## Risk assessment
- **Very low risk** — identical pattern to 3 existing fallbacks just above
- No impact on orders where shipping company is already populated (`empty()` guard)
- No impact on orders where billing company is also empty
- Benefits all marketplaces, not just Amazon

## Test plan
- [ ] Amazon B2B order: delivery.company=null, billing.company="Manfred Buecker" → company copied to shipping
- [ ] Amazon B2C order: both companies null → no change
- [ ] Order with delivery.company already set → no change (not overwritten)
- [ ] Non-Amazon marketplace with same structure → same fallback applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)