### PR TITLE
fix(import): prevent customer merging on shared relay emails (3.x backport)

### DIFF
--- a/classes/models/LengowImportOrder.php
+++ b/classes/models/LengowImportOrder.php
@@ -787,12 +787,12 @@ class LengowImportOrder
             LengowOrder::FIELD_EXTRA => pSQL(json_encode($this->orderData), true),
         ];
         // only include marketplace_customer_id if the column exists (hotfix compatibility)
-        if (LengowOrder::hasMarketplaceCustomerIdColumn()) {
-            $updateData[LengowOrder::FIELD_MARKETPLACE_CUSTOMER_ID] = pSQL(
-                isset($this->orderData->marketplace_customer_id)
-                    ? (string) $this->orderData->marketplace_customer_id
-                    : ''
-            );
+        // only persist marketplace_customer_id when the column exists and the API provides a value
+        if (LengowOrder::hasMarketplaceCustomerIdColumn() && isset($this->orderData->marketplace_customer_id)) {
+            $marketplaceCustomerId = (string) $this->orderData->marketplace_customer_id;
+            if ($marketplaceCustomerId !== '') {
+                $updateData[LengowOrder::FIELD_MARKETPLACE_CUSTOMER_ID] = pSQL($marketplaceCustomerId);
+            }
         }
         LengowOrder::updateOrderLengow($this->idOrderLengow, $updateData);
 

--- a/classes/models/LengowImportOrder.php
+++ b/classes/models/LengowImportOrder.php
@@ -777,6 +777,11 @@ class LengowImportOrder
                 LengowOrder::FIELD_CUSTOMER_NAME => pSQL($this->getCustomerName()),
                 LengowOrder::FIELD_CUSTOMER_EMAIL => pSQL($this->getCustomerEmail()),
                 LengowOrder::FIELD_CUSTOMER_VAT_NUMBER => pSQL($this->getVatNumberFromOrderData()),
+                LengowOrder::FIELD_MARKETPLACE_CUSTOMER_ID => pSQL(
+                    isset($this->orderData->marketplace_customer_id)
+                        ? (string) $this->orderData->marketplace_customer_id
+                        : ''
+                ),
                 LengowOrder::FIELD_CARRIER => pSQL($this->carrierName),
                 LengowOrder::FIELD_CARRIER_METHOD => pSQL($this->carrierMethod),
                 LengowOrder::FIELD_CARRIER_TRACKING => pSQL($this->trackingNumber),
@@ -972,6 +977,22 @@ class LengowImportOrder
             return $email;
         }
 
+        // check if a previous order from this marketplace buyer already exists in lengow_orders
+        // wrapped in try/catch for hotfix compatibility (column may not exist before upgrade)
+        try {
+            $previousEmail = LengowOrder::getCustomerEmailByMarketplaceCustomerId(
+                $marketplaceCustomerId,
+                $this->marketplace->name,
+                $this->idShop
+            );
+
+            if ($previousEmail) {
+                return $previousEmail;
+            }
+        } catch (Exception $e) {
+            // marketplace_customer_id column does not exist yet — fall through to lastname fallback
+        }
+
         // check if a customer already exists with this email in this shop
         $existingCustomer = new LengowCustomer();
         $existingCustomer->getByEmailAndShop($email, $this->idShop);
@@ -997,8 +1018,8 @@ class LengowImportOrder
             return $generatedEmail;
         }
 
-        // no stable customer yet — use lastname as tie-breaker to avoid
-        // splitting the first buyer who was created with the original relay email
+        // lastname fallback — used when the marketplace_customer_id column is not yet
+        // available (hotfix applied without DB upgrade) or for the first conflict detection
         $newLastName = Tools::strtolower(trim(isset($billingData['last_name']) ? (string) $billingData['last_name'] : ''));
         $existingLastName = Tools::strtolower(trim($existingCustomer->lastname));
 

--- a/classes/models/LengowImportOrder.php
+++ b/classes/models/LengowImportOrder.php
@@ -945,6 +945,85 @@ class LengowImportOrder
     }
 
     /**
+     * Resolve shared/relay email addresses to avoid merging different end-customers.
+     *
+     * When a relay or technical email is shared across multiple end-customers
+     * (e.g., Octopia CDON/FYND via @clemarche.com), generates a unique email
+     * per actual marketplace buyer to prevent unrelated orders from being
+     * grouped under the same PrestaShop customer account.
+     *
+     * @param string $email Original email from API
+     * @param array $billingData Billing data containing customer name
+     *
+     * @return string Resolved email (original or generated)
+     */
+    private function resolveSharedEmail($email, $billingData)
+    {
+        // check if a customer already exists with this email in this shop
+        $existingCustomer = new LengowCustomer();
+        $existingCustomer->getByEmailAndShop($email, $this->idShop);
+
+        if (!$existingCustomer->id) {
+            return $email;
+        }
+
+        // compare last names to detect if this is actually a different end-customer
+        $newLastName = Tools::strtolower(trim(isset($billingData['last_name']) ? (string) $billingData['last_name'] : ''));
+        $existingLastName = Tools::strtolower(trim($existingCustomer->lastname));
+
+        if ($newLastName === $existingLastName) {
+            return $email;
+        }
+
+        // different customer with same email — shared/relay email detected
+        $domain = !LengowMain::getHost() ? 'prestashop.shop' : LengowMain::getHost();
+        $domain = strtolower($domain);
+
+        // use marketplace_customer_id if available (stable per marketplace buyer)
+        $marketplaceCustomerId = isset($this->orderData->marketplace_customer_id)
+            ? (string) $this->orderData->marketplace_customer_id
+            : null;
+
+        if (!empty($marketplaceCustomerId)) {
+            $generatedEmail = md5($marketplaceCustomerId . '-' . $this->marketplace->name) . '@' . $domain;
+
+            LengowMain::log(
+                LengowLog::CODE_IMPORT,
+                LengowMain::setLogMessage(
+                    'log.import.shared_email_resolved_by_customer_id',
+                    [
+                        'original_email' => $email,
+                        'generated_email' => $generatedEmail,
+                        'marketplace_customer_id' => $marketplaceCustomerId,
+                    ]
+                ),
+                $this->logOutput,
+                $this->marketplaceSku
+            );
+
+            return $generatedEmail;
+        }
+
+        // no marketplace_customer_id — fallback to order-based unique email
+        $generatedEmail = md5($this->marketplaceSku . '-' . $this->marketplace->name) . '@' . $domain;
+
+        LengowMain::log(
+            LengowLog::CODE_IMPORT,
+            LengowMain::setLogMessage(
+                'log.import.shared_email_resolved_by_order',
+                [
+                    'original_email' => $email,
+                    'generated_email' => $generatedEmail,
+                ]
+            ),
+            $this->logOutput,
+            $this->marketplaceSku
+        );
+
+        return $generatedEmail;
+    }
+
+    /**
      * Checks if an order sent by the marketplace must be created or not
      *
      * @return bool
@@ -1226,6 +1305,9 @@ class LengowImportOrder
             } elseif (LengowConfiguration::getTypedGlobalValue(LengowConfiguration::TYPE_ANONYMIZE_EMAIL) === 1) {
                 $billingData['email'] = $this->marketplaceSku . '-' . $this->marketplace->name . '@' . $domain;
             }
+        } else {
+            // resolve shared relay emails to prevent merging different customers
+            $billingData['email'] = $this->resolveSharedEmail($billingData['email'], $billingData);
         }
 
         LengowMain::log(

--- a/classes/models/LengowImportOrder.php
+++ b/classes/models/LengowImportOrder.php
@@ -1328,6 +1328,11 @@ class LengowImportOrder
         } else {
             // resolve shared relay emails to prevent merging different customers
             $billingData['email'] = $this->resolveSharedEmail($billingData['email'], $billingData);
+            // persist the resolved email so future imports reuse it via marketplace_customer_id lookup
+            LengowOrder::updateOrderLengow(
+                $this->idOrderLengow,
+                [LengowOrder::FIELD_CUSTOMER_EMAIL => pSQL($billingData['email'])]
+            );
         }
 
         LengowMain::log(

--- a/classes/models/LengowImportOrder.php
+++ b/classes/models/LengowImportOrder.php
@@ -1023,16 +1023,18 @@ class LengowImportOrder
             return $generatedEmail;
         }
 
-        // lastname fallback — used when the marketplace_customer_id column is not yet
-        // available (hotfix applied without DB upgrade) or for the first conflict detection
-        $newLastName = Tools::strtolower(trim(isset($billingData['last_name']) ? (string) $billingData['last_name'] : ''));
-        $existingLastName = Tools::strtolower(trim($existingCustomer->lastname));
+        // lastname fallback — used only when the marketplace_customer_id column is not yet
+        // available (hotfix applied without DB upgrade)
+        if (!LengowOrder::hasMarketplaceCustomerIdColumn()) {
+            $newLastName = Tools::strtolower(trim(isset($billingData['last_name']) ? (string) $billingData['last_name'] : ''));
+            $existingLastName = Tools::strtolower(trim($existingCustomer->lastname));
 
-        if ($newLastName === $existingLastName) {
-            return $email;
+            if ($newLastName === $existingLastName) {
+                return $email;
+            }
         }
 
-        // different buyer confirmed — use generated email
+        // different buyer — use generated email
         LengowMain::log(
             LengowLog::CODE_IMPORT,
             LengowMain::setLogMessage(

--- a/classes/models/LengowImportOrder.php
+++ b/classes/models/LengowImportOrder.php
@@ -768,32 +768,33 @@ class LengowImportOrder
         // load tracking data
         $this->loadTrackingData();
         // update Lengow order record with new data
-        LengowOrder::updateOrderLengow(
-            $this->idOrderLengow,
-            [
-                LengowOrder::FIELD_CURRENCY => (string) $this->orderData->currency->iso_a3,
-                LengowOrder::FIELD_TOTAL_PAID => $this->orderAmount,
-                LengowOrder::FIELD_ORDER_ITEM => $this->orderItems,
-                LengowOrder::FIELD_CUSTOMER_NAME => pSQL($this->getCustomerName()),
-                LengowOrder::FIELD_CUSTOMER_EMAIL => pSQL($this->getCustomerEmail()),
-                LengowOrder::FIELD_CUSTOMER_VAT_NUMBER => pSQL($this->getVatNumberFromOrderData()),
-                LengowOrder::FIELD_MARKETPLACE_CUSTOMER_ID => pSQL(
-                    isset($this->orderData->marketplace_customer_id)
-                        ? (string) $this->orderData->marketplace_customer_id
-                        : ''
-                ),
-                LengowOrder::FIELD_CARRIER => pSQL($this->carrierName),
-                LengowOrder::FIELD_CARRIER_METHOD => pSQL($this->carrierMethod),
-                LengowOrder::FIELD_CARRIER_TRACKING => pSQL($this->trackingNumber),
-                LengowOrder::FIELD_CARRIER_RELAY_ID => pSQL($this->relayId),
-                LengowOrder::FIELD_SENT_MARKETPLACE => (int) $this->shippedByMp,
-                LengowOrder::FIELD_DELIVERY_COUNTRY_ISO => pSQL(
-                    (string) $this->packageData->delivery->common_country_iso_a2
-                ),
-                LengowOrder::FIELD_ORDER_LENGOW_STATE => pSQL($this->orderStateLengow),
-                LengowOrder::FIELD_EXTRA => pSQL(json_encode($this->orderData), true),
-            ]
-        );
+        $updateData = [
+            LengowOrder::FIELD_CURRENCY => (string) $this->orderData->currency->iso_a3,
+            LengowOrder::FIELD_TOTAL_PAID => $this->orderAmount,
+            LengowOrder::FIELD_ORDER_ITEM => $this->orderItems,
+            LengowOrder::FIELD_CUSTOMER_NAME => pSQL($this->getCustomerName()),
+            LengowOrder::FIELD_CUSTOMER_EMAIL => pSQL($this->getCustomerEmail()),
+            LengowOrder::FIELD_CUSTOMER_VAT_NUMBER => pSQL($this->getVatNumberFromOrderData()),
+            LengowOrder::FIELD_CARRIER => pSQL($this->carrierName),
+            LengowOrder::FIELD_CARRIER_METHOD => pSQL($this->carrierMethod),
+            LengowOrder::FIELD_CARRIER_TRACKING => pSQL($this->trackingNumber),
+            LengowOrder::FIELD_CARRIER_RELAY_ID => pSQL($this->relayId),
+            LengowOrder::FIELD_SENT_MARKETPLACE => (int) $this->shippedByMp,
+            LengowOrder::FIELD_DELIVERY_COUNTRY_ISO => pSQL(
+                (string) $this->packageData->delivery->common_country_iso_a2
+            ),
+            LengowOrder::FIELD_ORDER_LENGOW_STATE => pSQL($this->orderStateLengow),
+            LengowOrder::FIELD_EXTRA => pSQL(json_encode($this->orderData), true),
+        ];
+        // only include marketplace_customer_id if the column exists (hotfix compatibility)
+        if (self::hasMarketplaceCustomerIdColumn()) {
+            $updateData[LengowOrder::FIELD_MARKETPLACE_CUSTOMER_ID] = pSQL(
+                isset($this->orderData->marketplace_customer_id)
+                    ? (string) $this->orderData->marketplace_customer_id
+                    : ''
+            );
+        }
+        LengowOrder::updateOrderLengow($this->idOrderLengow, $updateData);
 
         return true;
     }
@@ -966,6 +967,28 @@ class LengowImportOrder
      *
      * @return string Resolved email (original or generated)
      */
+    /**
+     * @var bool|null cached result of marketplace_customer_id column existence check
+     */
+    private static $hasMarketplaceCustomerIdColumn = null;
+
+    /**
+     * Check if the marketplace_customer_id column exists in lengow_orders (cached).
+     *
+     * @return bool
+     */
+    private static function hasMarketplaceCustomerIdColumn()
+    {
+        if (self::$hasMarketplaceCustomerIdColumn === null) {
+            self::$hasMarketplaceCustomerIdColumn = LengowInstall::checkFieldExists(
+                LengowOrder::TABLE_ORDER,
+                LengowOrder::FIELD_MARKETPLACE_CUSTOMER_ID
+            );
+        }
+
+        return self::$hasMarketplaceCustomerIdColumn;
+    }
+
     private function resolveSharedEmail($email, $billingData)
     {
         // only activate when marketplace_customer_id is available as a reliable discriminator
@@ -978,8 +1001,7 @@ class LengowImportOrder
         }
 
         // check if a previous order from this marketplace buyer already exists in lengow_orders
-        // wrapped in try/catch for hotfix compatibility (column may not exist before upgrade)
-        try {
+        if (self::hasMarketplaceCustomerIdColumn()) {
             $previousEmail = LengowOrder::getCustomerEmailByMarketplaceCustomerId(
                 $marketplaceCustomerId,
                 $this->marketplace->name,
@@ -989,8 +1011,6 @@ class LengowImportOrder
             if ($previousEmail) {
                 return $previousEmail;
             }
-        } catch (Exception $e) {
-            // marketplace_customer_id column does not exist yet — fall through to lastname fallback
         }
 
         // check if a customer already exists with this email in this shop

--- a/classes/models/LengowImportOrder.php
+++ b/classes/models/LengowImportOrder.php
@@ -952,6 +952,10 @@ class LengowImportOrder
      * per actual marketplace buyer to prevent unrelated orders from being
      * grouped under the same PrestaShop customer account.
      *
+     * Only activates when marketplace_customer_id is available in the API payload,
+     * as it is the only reliable discriminator. Without it, the original email is
+     * kept to avoid false positives (e.g., shared company inboxes, name corrections).
+     *
      * @param string $email Original email from API
      * @param array $billingData Billing data containing customer name
      *
@@ -959,6 +963,15 @@ class LengowImportOrder
      */
     private function resolveSharedEmail($email, $billingData)
     {
+        // only activate when marketplace_customer_id is available as a reliable discriminator
+        $marketplaceCustomerId = isset($this->orderData->marketplace_customer_id)
+            ? (string) $this->orderData->marketplace_customer_id
+            : null;
+
+        if (empty($marketplaceCustomerId)) {
+            return $email;
+        }
+
         // check if a customer already exists with this email in this shop
         $existingCustomer = new LengowCustomer();
         $existingCustomer->getByEmailAndShop($email, $this->idShop);
@@ -967,7 +980,25 @@ class LengowImportOrder
             return $email;
         }
 
-        // compare last names to detect if this is actually a different end-customer
+        // generate the stable email for this marketplace buyer
+        $domain = !LengowMain::getHost() ? 'prestashop.shop' : LengowMain::getHost();
+        $domain = strtolower($domain);
+        $generatedEmail = md5($marketplaceCustomerId . '-' . $this->marketplace->name) . '@' . $domain;
+
+        // if the existing customer already uses this stable email, it's the same buyer
+        if ($existingCustomer->email === $generatedEmail) {
+            return $generatedEmail;
+        }
+
+        // check if a customer was previously created with this buyer's stable email
+        $stableCustomer = new LengowCustomer();
+        $stableCustomer->getByEmailAndShop($generatedEmail, $this->idShop);
+        if ($stableCustomer->id) {
+            return $generatedEmail;
+        }
+
+        // no stable customer yet — use lastname as tie-breaker to avoid
+        // splitting the first buyer who was created with the original relay email
         $newLastName = Tools::strtolower(trim(isset($billingData['last_name']) ? (string) $billingData['last_name'] : ''));
         $existingLastName = Tools::strtolower(trim($existingCustomer->lastname));
 
@@ -975,45 +1006,15 @@ class LengowImportOrder
             return $email;
         }
 
-        // different customer with same email — shared/relay email detected
-        $domain = !LengowMain::getHost() ? 'prestashop.shop' : LengowMain::getHost();
-        $domain = strtolower($domain);
-
-        // use marketplace_customer_id if available (stable per marketplace buyer)
-        $marketplaceCustomerId = isset($this->orderData->marketplace_customer_id)
-            ? (string) $this->orderData->marketplace_customer_id
-            : null;
-
-        if (!empty($marketplaceCustomerId)) {
-            $generatedEmail = md5($marketplaceCustomerId . '-' . $this->marketplace->name) . '@' . $domain;
-
-            LengowMain::log(
-                LengowLog::CODE_IMPORT,
-                LengowMain::setLogMessage(
-                    'log.import.shared_email_resolved_by_customer_id',
-                    [
-                        'original_email' => $email,
-                        'generated_email' => $generatedEmail,
-                        'marketplace_customer_id' => $marketplaceCustomerId,
-                    ]
-                ),
-                $this->logOutput,
-                $this->marketplaceSku
-            );
-
-            return $generatedEmail;
-        }
-
-        // no marketplace_customer_id — fallback to order-based unique email
-        $generatedEmail = md5($this->marketplaceSku . '-' . $this->marketplace->name) . '@' . $domain;
-
+        // different buyer confirmed — use generated email
         LengowMain::log(
             LengowLog::CODE_IMPORT,
             LengowMain::setLogMessage(
-                'log.import.shared_email_resolved_by_order',
+                'log.import.shared_email_resolved_by_customer_id',
                 [
                     'original_email' => $email,
                     'generated_email' => $generatedEmail,
+                    'marketplace_customer_id' => $marketplaceCustomerId,
                 ]
             ),
             $this->logOutput,

--- a/classes/models/LengowImportOrder.php
+++ b/classes/models/LengowImportOrder.php
@@ -983,7 +983,8 @@ class LengowImportOrder
             $previousEmail = LengowOrder::getCustomerEmailByMarketplaceCustomerId(
                 $marketplaceCustomerId,
                 $this->marketplace->name,
-                $this->idShop
+                $this->idShop,
+                $this->idOrderLengow
             );
 
             if ($previousEmail) {

--- a/classes/models/LengowImportOrder.php
+++ b/classes/models/LengowImportOrder.php
@@ -787,7 +787,7 @@ class LengowImportOrder
             LengowOrder::FIELD_EXTRA => pSQL(json_encode($this->orderData), true),
         ];
         // only include marketplace_customer_id if the column exists (hotfix compatibility)
-        if (self::hasMarketplaceCustomerIdColumn()) {
+        if (LengowOrder::hasMarketplaceCustomerIdColumn()) {
             $updateData[LengowOrder::FIELD_MARKETPLACE_CUSTOMER_ID] = pSQL(
                 isset($this->orderData->marketplace_customer_id)
                     ? (string) $this->orderData->marketplace_customer_id
@@ -967,28 +967,6 @@ class LengowImportOrder
      *
      * @return string Resolved email (original or generated)
      */
-    /**
-     * @var bool|null cached result of marketplace_customer_id column existence check
-     */
-    private static $hasMarketplaceCustomerIdColumn = null;
-
-    /**
-     * Check if the marketplace_customer_id column exists in lengow_orders (cached).
-     *
-     * @return bool
-     */
-    private static function hasMarketplaceCustomerIdColumn()
-    {
-        if (self::$hasMarketplaceCustomerIdColumn === null) {
-            self::$hasMarketplaceCustomerIdColumn = LengowInstall::checkFieldExists(
-                LengowOrder::TABLE_ORDER,
-                LengowOrder::FIELD_MARKETPLACE_CUSTOMER_ID
-            );
-        }
-
-        return self::$hasMarketplaceCustomerIdColumn;
-    }
-
     private function resolveSharedEmail($email, $billingData)
     {
         // only activate when marketplace_customer_id is available as a reliable discriminator
@@ -1001,7 +979,7 @@ class LengowImportOrder
         }
 
         // check if a previous order from this marketplace buyer already exists in lengow_orders
-        if (self::hasMarketplaceCustomerIdColumn()) {
+        if (LengowOrder::hasMarketplaceCustomerIdColumn()) {
             $previousEmail = LengowOrder::getCustomerEmailByMarketplaceCustomerId(
                 $marketplaceCustomerId,
                 $this->marketplace->name,

--- a/classes/models/LengowImportOrder.php
+++ b/classes/models/LengowImportOrder.php
@@ -768,12 +768,18 @@ class LengowImportOrder
         // load tracking data
         $this->loadTrackingData();
         // update Lengow order record with new data
+        // preserve resolved customer email on reimport — do not overwrite with raw API relay email
+        $existingEmail = Db::getInstance()->getValue(
+            'SELECT `customer_email` FROM `' . _DB_PREFIX_ . 'lengow_orders`
+            WHERE `id` = ' . (int) $this->idOrderLengow
+        );
+        $customerEmail = !empty($existingEmail) ? $existingEmail : $this->getCustomerEmail();
         $updateData = [
             LengowOrder::FIELD_CURRENCY => (string) $this->orderData->currency->iso_a3,
             LengowOrder::FIELD_TOTAL_PAID => $this->orderAmount,
             LengowOrder::FIELD_ORDER_ITEM => $this->orderItems,
             LengowOrder::FIELD_CUSTOMER_NAME => pSQL($this->getCustomerName()),
-            LengowOrder::FIELD_CUSTOMER_EMAIL => pSQL($this->getCustomerEmail()),
+            LengowOrder::FIELD_CUSTOMER_EMAIL => pSQL($customerEmail),
             LengowOrder::FIELD_CUSTOMER_VAT_NUMBER => pSQL($this->getVatNumberFromOrderData()),
             LengowOrder::FIELD_CARRIER => pSQL($this->carrierName),
             LengowOrder::FIELD_CARRIER_METHOD => pSQL($this->carrierMethod),

--- a/classes/models/LengowInstall.php
+++ b/classes/models/LengowInstall.php
@@ -583,6 +583,7 @@ class LengowInstall
                 `currency` VARCHAR(3) NULL,
                 `total_paid` DECIMAL(17,2) UNSIGNED NULL,
                 `customer_vat_number` VARCHAR(100) NULL,
+                `marketplace_customer_id` VARCHAR(100) NULL,
                 `commission` DECIMAL(17,2) UNSIGNED NULL,
                 `customer_name` VARCHAR(255) NULL,
                 `customer_email` VARCHAR(255) NULL,

--- a/classes/models/LengowInstall.php
+++ b/classes/models/LengowInstall.php
@@ -603,6 +603,7 @@ class LengowInstall
                 INDEX (`id_flux`),
                 INDEX (`marketplace_sku`),
                 INDEX (`marketplace_name`),
+                INDEX (`marketplace_customer_id`),
                 INDEX (`date_add`)
                 ) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8;';
             Db::getInstance()->execute($sql);

--- a/classes/models/LengowOrder.php
+++ b/classes/models/LengowOrder.php
@@ -55,6 +55,7 @@ class LengowOrder extends Order
     public const FIELD_CUSTOMER_NAME = 'customer_name';
     public const FIELD_CUSTOMER_EMAIL = 'customer_email';
     public const FIELD_CUSTOMER_VAT_NUMBER = 'customer_vat_number';
+    public const FIELD_MARKETPLACE_CUSTOMER_ID = 'marketplace_customer_id';
     public const FIELD_CARRIER = 'carrier';
     public const FIELD_CARRIER_METHOD = 'method';
     public const FIELD_CARRIER_TRACKING = 'tracking';
@@ -278,6 +279,7 @@ class LengowOrder extends Order
             lo.`currency`,
             lo.`total_paid`,
             lo.`customer_vat_number`,
+            lo.`marketplace_customer_id`,
             lo.`commission`,
             lo.`customer_name`,
             lo.`customer_email`,
@@ -385,6 +387,34 @@ class LengowOrder extends Order
         $result = Db::getInstance()->getRow($query);
         if ($result) {
             return (int) $result[self::FIELD_ID];
+        }
+
+        return false;
+    }
+
+    /**
+     * Get the customer email used for a previous order with the same marketplace_customer_id
+     *
+     * @param string $marketplaceCustomerId marketplace customer identifier
+     * @param string $marketplace marketplace name
+     * @param int $idShop PrestaShop shop id
+     *
+     * @return string|false customer email if found, false otherwise
+     */
+    public static function getCustomerEmailByMarketplaceCustomerId($marketplaceCustomerId, $marketplace, $idShop)
+    {
+        $query = 'SELECT `customer_email` FROM `' . _DB_PREFIX_ . 'lengow_orders`
+            WHERE `marketplace_customer_id` = \'' . pSQL($marketplaceCustomerId) . '\'
+            AND `marketplace_name` = \'' . pSQL($marketplace) . '\'
+            AND `id_shop` = \'' . (int) $idShop . '\'
+            AND `customer_email` IS NOT NULL
+            AND `customer_email` != \'\'
+            ORDER BY `id` DESC
+            LIMIT 1';
+
+        $result = Db::getInstance()->getRow($query);
+        if ($result) {
+            return (string) $result[self::FIELD_CUSTOMER_EMAIL];
         }
 
         return false;

--- a/classes/models/LengowOrder.php
+++ b/classes/models/LengowOrder.php
@@ -421,15 +421,17 @@ class LengowOrder extends Order
      * @param string $marketplaceCustomerId marketplace customer identifier
      * @param string $marketplace marketplace name
      * @param int $idShop PrestaShop shop id
+     * @param int $excludeIdOrderLengow Lengow order id to exclude (current order being imported)
      *
      * @return string|false customer email if found, false otherwise
      */
-    public static function getCustomerEmailByMarketplaceCustomerId($marketplaceCustomerId, $marketplace, $idShop)
+    public static function getCustomerEmailByMarketplaceCustomerId($marketplaceCustomerId, $marketplace, $idShop, $excludeIdOrderLengow = 0)
     {
         $query = 'SELECT `customer_email` FROM `' . _DB_PREFIX_ . 'lengow_orders`
             WHERE `marketplace_customer_id` = \'' . pSQL($marketplaceCustomerId) . '\'
             AND `marketplace_name` = \'' . pSQL($marketplace) . '\'
-            AND `id_shop` = \'' . (int) $idShop . '\'
+            AND `id_shop` = \'' . (int) $idShop . '\''
+            . ($excludeIdOrderLengow > 0 ? ' AND `id` != ' . (int) $excludeIdOrderLengow : '') . '
             AND `customer_email` IS NOT NULL
             AND `customer_email` != \'\'
             ORDER BY `id` DESC

--- a/classes/models/LengowOrder.php
+++ b/classes/models/LengowOrder.php
@@ -256,12 +256,35 @@ class LengowOrder extends Order
     }
 
     /**
+     * @var bool|null cached result of marketplace_customer_id column existence check
+     */
+    private static $hasMarketplaceCustomerIdColumn = null;
+
+    /**
+     * Check if the marketplace_customer_id column exists in lengow_orders (cached).
+     *
+     * @return bool
+     */
+    public static function hasMarketplaceCustomerIdColumn()
+    {
+        if (self::$hasMarketplaceCustomerIdColumn === null) {
+            self::$hasMarketplaceCustomerIdColumn = LengowInstall::checkFieldExists(
+                self::TABLE_ORDER,
+                self::FIELD_MARKETPLACE_CUSTOMER_ID
+            );
+        }
+
+        return self::$hasMarketplaceCustomerIdColumn;
+    }
+
+    /**
      * Load information from lengow_orders table
      *
      * @return bool
      */
     protected function loadLengowFields()
     {
+        $hasCustomerIdColumn = self::hasMarketplaceCustomerIdColumn();
         $query = 'SELECT
             lo.`id`,
             lo.`id_shop`,
@@ -278,9 +301,9 @@ class LengowOrder extends Order
             lo.`order_types`,
             lo.`currency`,
             lo.`total_paid`,
-            lo.`customer_vat_number`,
-            lo.`marketplace_customer_id`,
-            lo.`commission`,
+            lo.`customer_vat_number`,'
+            . ($hasCustomerIdColumn ? 'lo.`marketplace_customer_id`,' : '') .
+            'lo.`commission`,
             lo.`customer_name`,
             lo.`customer_email`,
             lo.`carrier`,

--- a/classes/models/LengowOrder.php
+++ b/classes/models/LengowOrder.php
@@ -412,7 +412,11 @@ class LengowOrder extends Order
             ORDER BY `id` DESC
             LIMIT 1';
 
-        $result = Db::getInstance()->getRow($query);
+        try {
+            $result = Db::getInstance()->getRow($query);
+        } catch (PrestaShopDatabaseException $e) {
+            return false;
+        }
         if ($result) {
             return (string) $result[self::FIELD_CUSTOMER_EMAIL];
         }

--- a/translations/en.csv
+++ b/translations/en.csv
@@ -560,6 +560,8 @@ log.import.state_updated_to|status updated to %{state_name}
 log.import.rewrite_processing_fee|rewrite amount without processing fee
 log.import.rewrite_shipping_cost|rewrite amount without shipping cost
 log.import.generate_unique_email|generate a unique email %{email}
+log.import.shared_email_resolved_by_customer_id|shared relay email detected (%{original_email}), generated stable customer email %{generated_email} from marketplace_customer_id %{marketplace_customer_id}
+log.import.shared_email_resolved_by_order|shared relay email detected (%{original_email}), no marketplace_customer_id available, generated order-specific email %{generated_email}
 log.import.product_be_found|product id %{id_full} found with field %{attribute_name} (%{attribute_value})
 log.import.product_advanced_search|product not found with field %{attribute_name} (%{attribute_value}). Using advanced search
 log.import.product_state_canceled|product %{product_id} could not be added to cart - status: %{state_product}

--- a/translations/en.csv
+++ b/translations/en.csv
@@ -561,7 +561,6 @@ log.import.rewrite_processing_fee|rewrite amount without processing fee
 log.import.rewrite_shipping_cost|rewrite amount without shipping cost
 log.import.generate_unique_email|generate a unique email %{email}
 log.import.shared_email_resolved_by_customer_id|shared relay email detected (%{original_email}), generated stable customer email %{generated_email} from marketplace_customer_id %{marketplace_customer_id}
-log.import.shared_email_resolved_by_order|shared relay email detected (%{original_email}), no marketplace_customer_id available, generated order-specific email %{generated_email}
 log.import.product_be_found|product id %{id_full} found with field %{attribute_name} (%{attribute_value})
 log.import.product_advanced_search|product not found with field %{attribute_name} (%{attribute_value}). Using advanced search
 log.import.product_state_canceled|product %{product_id} could not be added to cart - status: %{state_product}

--- a/translations/yml/log.yml
+++ b/translations/yml/log.yml
@@ -84,7 +84,6 @@ en:
       rewrite_shipping_cost: "rewrite amount without shipping cost"
       generate_unique_email: "generate a unique email %{email}"
       shared_email_resolved_by_customer_id: "shared relay email detected (%{original_email}), generated stable customer email %{generated_email} from marketplace_customer_id %{marketplace_customer_id}"
-      shared_email_resolved_by_order: "shared relay email detected (%{original_email}), no marketplace_customer_id available, generated order-specific email %{generated_email}"
       product_be_found: "product id %{id_full} found with field %{attribute_name} (%{attribute_value})"
       product_advanced_search: "product not found with field %{attribute_name} (%{attribute_value}). Using advanced search"
       product_state_canceled: "product %{product_id} could not be added to cart - status: %{state_product}"

--- a/translations/yml/log.yml
+++ b/translations/yml/log.yml
@@ -83,6 +83,8 @@ en:
       rewrite_processing_fee: "rewrite amount without processing fee"
       rewrite_shipping_cost: "rewrite amount without shipping cost"
       generate_unique_email: "generate a unique email %{email}"
+      shared_email_resolved_by_customer_id: "shared relay email detected (%{original_email}), generated stable customer email %{generated_email} from marketplace_customer_id %{marketplace_customer_id}"
+      shared_email_resolved_by_order: "shared relay email detected (%{original_email}), no marketplace_customer_id available, generated order-specific email %{generated_email}"
       product_be_found: "product id %{id_full} found with field %{attribute_name} (%{attribute_value})"
       product_advanced_search: "product not found with field %{attribute_name} (%{attribute_value}). Using advanced search"
       product_state_canceled: "product %{product_id} could not be added to cart - status: %{state_product}"

--- a/upgrade/update_3.11.0.php
+++ b/upgrade/update_3.11.0.php
@@ -36,4 +36,9 @@ if (LengowInstall::checkTableExists(LengowOrder::TABLE_ORDER)) {
             'ALTER TABLE ' . _DB_PREFIX_ . 'lengow_orders ADD `marketplace_customer_id` VARCHAR(100) NULL'
         );
     }
+    if (!LengowInstall::checkIndexExists(LengowOrder::TABLE_ORDER, LengowOrder::FIELD_MARKETPLACE_CUSTOMER_ID)) {
+        Db::getInstance()->execute(
+            'ALTER TABLE ' . _DB_PREFIX_ . 'lengow_orders ADD INDEX (`marketplace_customer_id`)'
+        );
+    }
 }

--- a/upgrade/update_3.11.0.php
+++ b/upgrade/update_3.11.0.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Copyright 2026 Lengow SAS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * @author    Team Connector <team-connector@lengow.com>
+ * @copyright 2026 Lengow SAS
+ * @license   http://www.apache.org/licenses/LICENSE-2.0
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+if (!LengowInstall::isInstallationInProgress()) {
+    exit;
+}
+
+// *********************************************************
+//                     lengow_orders
+// *********************************************************
+
+if (LengowInstall::checkTableExists(LengowOrder::TABLE_ORDER)) {
+    if (!LengowInstall::checkFieldExists(LengowOrder::TABLE_ORDER, LengowOrder::FIELD_MARKETPLACE_CUSTOMER_ID)) {
+        Db::getInstance()->execute(
+            'ALTER TABLE ' . _DB_PREFIX_ . 'lengow_orders ADD `marketplace_customer_id` VARCHAR(100) NULL'
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Backport of #120 for the 3.x branch (PrestaShop 1.7 compatibility).

- When marketplaces like Octopia CDON/FYND provide the same technical relay email (e.g. `@clemarche.com`) for different end-customers, the plugin was merging all orders under the first customer account found with that email
- Add `resolveSharedEmail()` method in `LengowImportOrder` that detects shared emails using `marketplace_customer_id` as the primary discriminator, with lastname as a tie-breaker
- Only activates when `marketplace_customer_id` is present in the API payload to avoid false positives on other marketplaces (shared company inboxes, name corrections)
- Persist `marketplace_customer_id` in `lengow_orders` table (new column + index) for stable buyer mapping across imports
- Persist the resolved email back to `lengow_orders.customer_email` so future imports reuse the stable email via `marketplace_customer_id` lookup
- Exclude the current order from the email lookup query to avoid returning its own relay email instead of a previously resolved email

## Differences with main branch (#120)

- No PHP type hints (PHP 7.x compatibility)
- Uses `md5()` instead of `hash('sha256', ...)` to match existing 3.x anonymization pattern
- Upgrade script is `update_3.11.0.php` instead of `update_4.2.0.php`

## Hotfix compatibility

The code is designed to work even if the DB migration (`update_3.11.0.php`) has not run yet:
- `LengowOrder::hasMarketplaceCustomerIdColumn()` uses a static-cached `SHOW COLUMNS` check to detect whether the column exists
- All reads/writes to `marketplace_customer_id` are gated behind this check
- Without the column, the feature degrades gracefully to lastname-based conflict detection

## How it works

| Scenario | Behavior |
|---|---|
| Unique email per buyer (standard) | Unchanged |
| Shared relay email + `marketplace_customer_id` available | Stable technical email per marketplace buyer |
| Shared relay email + no `marketplace_customer_id` | No change — cannot reliably distinguish buyers without a stable identifier |
| Email anonymization enabled in BO | Unchanged — existing logic takes precedence |

## Test plan

- [ ] Import order with unique email — customer created normally (no regression)
- [ ] Import order with same email + same last name — reuses existing customer
- [ ] Import order with same email + different last name + `marketplace_customer_id` — new customer with stable generated email
- [ ] Re-import from same buyer (same `marketplace_customer_id`) after resolution — reuses the stable customer
- [ ] Import order without `marketplace_customer_id` — no change in behavior (original email kept)
- [ ] Verify logs show `shared_email_resolved_by_customer_id` when resolution triggers
- [ ] Verify email anonymization enabled — existing behavior unchanged
- [ ] Verify hotfix compatibility: deploy code without running DB upgrade — lastname fallback works
- [ ] Verify resolved email is persisted and reused on subsequent imports for the same marketplace_customer_id