### PR TITLE
fix: recognize MariaDB duplicate-key message when registering hooks

### DIFF
--- a/classes/models/LengowHook.php
+++ b/classes/models/LengowHook.php
@@ -136,8 +136,13 @@ class LengowHook
      */
     private function isDuplicateHookRegistrationException(Exception $exception): bool
     {
+        // MySQL >= 8.0.19 qualifies the index name with the table ("hook_module.PRIMARY"),
+        // while MariaDB and MySQL < 8.0.19 only report "for key 'PRIMARY'".
         return str_contains($exception->getMessage(), 'Duplicate entry')
-            && str_contains($exception->getMessage(), 'hook_module.PRIMARY');
+            && (
+                str_contains($exception->getMessage(), 'hook_module.PRIMARY')
+                || str_contains($exception->getMessage(), "for key 'PRIMARY'")
+            );
     }
 
     /**


### PR DESCRIPTION
### Problem

Updating the plugin (4.0.x → 4.1.0) crashes with a fatal error on the **whole shop** on MariaDB / MySQL < 8.0.19:

```
Uncaught PDOException: SQLSTATE[23000]: Integrity constraint violation:
1062 Duplicate entry '115-1257-1' for key 'PRIMARY'
  in classes/db/DbPDO.php:147
#4 classes/Hook.php(685): DbCore->insert()
#5 classes/module/Module.php(1215): HookCore::registerHook()
#6 classes/models/LengowHook.php(93): ModuleCore->registerHook()
#7 classes/models/LengowInstall.php(349): LengowHook->registerHooks()
#8 lengow.php(81): LengowInstall->update()
```

(`115` = lengow module id, `1257` = `orderConfirmation` hook, `1` = shop → `ps_hook_module` PK `(id_module, id_hook, id_shop)`)

### Root cause

`registerHooks()` re-registers all hooks on update. For the legacy alias hook `orderConfirmation`, `isRegisteredForCurrentContext()` resolves the name via `Hook::getIdByName()` (which canonicalizes the alias to a different id), so the already-existing registration isn't detected and `registerHook()` is called again → duplicate PK insert.

The `catch` that is meant to swallow exactly this only recognized the **MySQL ≥ 8.0.19** message format, which qualifies the index with the table name (`hook_module.PRIMARY`). On **MariaDB / MySQL < 8.0.19** the message is `... for key 'PRIMARY'` (unqualified), so `isDuplicateHookRegistrationException()` returned `false`, the exception was re-thrown, and the update aborted.

### Fix

Also match the unqualified `for key 'PRIMARY'` form.

### Tested

Reproduced and verified end-to-end on **PrestaShop 9.0.3 / MariaDB 10.6.22**:

| Before | After |
|---|---|
| Fatal error on every page | Homepage HTTP 200 |
| `update()` aborts, version stuck at 4.0.2 | `update()` completes, `LENGOW_VERSION` = 4.1.0 |
| Exception re-thrown | Exception caught, existing hook registration preserved (single `ps_hook_module` row, no duplicate) |