### PR TITLE
fix(install): prevent duplicate hook registration crash on MySQL and MariaDB (3.x backport)

### DIFF
--- a/classes/models/LengowHook.php
+++ b/classes/models/LengowHook.php
@@ -130,7 +130,28 @@ class LengowHook
                 if ($this->module->isRegisteredInHook($hook)) {
                     continue;
                 }
-                if (!$this->module->registerHook($hook)) {
+                try {
+                    $registered = $this->module->registerHook($hook);
+                } catch (PrestaShopDatabaseException $e) {
+                    if (!self::isDuplicateHookRegistrationException($e)) {
+                        throw $e;
+                    }
+                    LengowMain::log(
+                        LengowLog::CODE_INSTALL,
+                        LengowMain::setLogMessage('log.install.registering_hook_success', ['hook' => $hook])
+                    );
+                    continue;
+                } catch (PrestaShopException $e) {
+                    if (!self::isDuplicateHookRegistrationException($e)) {
+                        throw $e;
+                    }
+                    LengowMain::log(
+                        LengowLog::CODE_INSTALL,
+                        LengowMain::setLogMessage('log.install.registering_hook_success', ['hook' => $hook])
+                    );
+                    continue;
+                }
+                if (!$registered) {
                     LengowMain::log(
                         LengowLog::CODE_INSTALL,
                         LengowMain::setLogMessage('log.install.registering_hook_error', ['hook' => $hook])
@@ -146,6 +167,25 @@ class LengowHook
         }
 
         return !$error;
+    }
+
+    /**
+     * Check if an exception is a duplicate hook registration (MySQL or MariaDB)
+     *
+     * MySQL >= 8.0.19: "Duplicate entry '...' for key 'hook_module.PRIMARY'"
+     * MariaDB / MySQL < 8.0.19: "Duplicate entry '...' for key 'PRIMARY'"
+     *
+     * @param Exception $exception
+     *
+     * @return bool
+     */
+    private static function isDuplicateHookRegistrationException($exception)
+    {
+        $message = $exception->getMessage();
+
+        return strpos($message, 'Duplicate entry') !== false
+            && (strpos($message, 'hook_module.PRIMARY') !== false
+                || strpos($message, "for key 'PRIMARY'") !== false);
     }
 
     /**

--- a/classes/models/LengowHook.php
+++ b/classes/models/LengowHook.php
@@ -132,16 +132,7 @@ class LengowHook
                 }
                 try {
                     $registered = $this->module->registerHook($hook);
-                } catch (PrestaShopDatabaseException $e) {
-                    if (!self::isDuplicateHookRegistrationException($e)) {
-                        throw $e;
-                    }
-                    LengowMain::log(
-                        LengowLog::CODE_INSTALL,
-                        LengowMain::setLogMessage('log.install.registering_hook_success', ['hook' => $hook])
-                    );
-                    continue;
-                } catch (PrestaShopException $e) {
+                } catch (PrestaShopDatabaseException | PrestaShopException $e) {
                     if (!self::isDuplicateHookRegistrationException($e)) {
                         throw $e;
                     }


### PR DESCRIPTION
## Summary

Backport of main PRs #110 and #122 for the 3.x branch.

- When updating the plugin, `registerHooks()` re-registers all hooks. For alias hooks like `orderConfirmation`, `isRegisteredInHook()` may not detect the existing registration, causing a duplicate PK insert that crashes the entire shop
- Adds a try/catch around `registerHook()` that swallows duplicate-key exceptions
- Handles both MySQL >= 8.0.19 (qualified key: `hook_module.PRIMARY`) and MariaDB / MySQL < 8.0.19 (unqualified key: `PRIMARY`)

## Context

- The 3.x branch had **no protection at all** against duplicate hook registration exceptions
- Main branch had partial protection (PR #110) but only for MySQL 8+ format, fixed for MariaDB in PR #122
- This backport includes both fixes combined

## Test plan

- [ ] Update plugin on MariaDB — no crash, hooks registered correctly
- [ ] Update plugin on MySQL 8+ — no crash, hooks registered correctly
- [ ] Fresh install — hooks register normally (no exception path hit)
- [ ] Non-duplicate DB exception — still propagated (not swallowed)