### PR TITLE
fix: address PrestaShop Addons validator issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,11 @@ config/marketplaces.json
 tools/vars.sh
 .php_cs.cache
 .php-cs-fixer.cache
+
+# Personal / temp files (must not leak into builds)
+/*.py
+/lenwgoCustom.php
+/debug_*.php
+/*.txt
+!/license.txt
+/image-*.png

--- a/classes/models/LengowCarrier.php
+++ b/classes/models/LengowCarrier.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Copyright 2021 Lengow SAS.
  *

--- a/classes/models/LengowCarrier.php
+++ b/classes/models/LengowCarrier.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright 2021 Lengow SAS.
  *
@@ -1306,11 +1307,12 @@ class LengowCarrier extends Carrier
         $filePath = _PS_MODULE_DIR_ . $moduleName . $sep . 'classes' . $sep . 'module.classes.php';
         $loaded = include_once $filePath;
         if (!$loaded) {
-            throw new LengowException(
-                LengowMain::setLogMessage('log.import.error_colissimo_new_missing_file', ['file_path' => $filePath])
-            );
+            throw new LengowException(LengowMain::setLogMessage('log.import.error_colissimo_new_missing_file', ['file_path' => $filePath]));
         }
         $carrier = new Carrier($idCarrier);
+        if (!class_exists('ColissimoService') || !class_exists('ColissimoPickupPoint') || !class_exists('ColissimoCartPickupPoint')) {
+            throw new LengowException(LengowMain::setLogMessage('log.import.error_colissimo_new_missing_file', ['file_path' => $filePath]));
+        }
         $serviceType = ColissimoService::getServiceTypeByIdCarrier((int) $carrier->id_reference);
         if ($serviceType === ColissimoService::TYPE_RELAIS && !empty($shippingAddress->idRelay)) {
             $colissimoId = Tools::substr((string) $shippingAddress->idRelay, 0, 8);
@@ -1341,7 +1343,7 @@ class LengowCarrier extends Carrier
                 $isoCountry = Country::getIsoById($shippingAddress->id_country);
                 $pickupPoint->iso_country = $isoCountry;
                 $countryName = Country::getNameById(
-                    (int) Context::getContext()->language->id,
+                    (int) LengowContext::getContext()->language->id,
                     (int) $shippingAddress->id_country
                 );
                 $pickupPoint->country = Tools::substr($countryName ?: $isoCountry, 0, 64);

--- a/classes/models/LengowOrder.php
+++ b/classes/models/LengowOrder.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Copyright 2017 Lengow SAS.
  *

--- a/classes/models/LengowOrder.php
+++ b/classes/models/LengowOrder.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright 2017 Lengow SAS.
  *
@@ -433,7 +434,7 @@ class LengowOrder extends Order
         string $marketplaceCustomerId,
         string $marketplace,
         int $idShop,
-        int $excludeIdOrderLengow = 0
+        int $excludeIdOrderLengow = 0,
     ): string|false {
         $query = 'SELECT `customer_email` FROM `' . _DB_PREFIX_ . 'lengow_orders`
             WHERE `marketplace_customer_id` = \'' . pSQL($marketplaceCustomerId) . '\'
@@ -447,7 +448,7 @@ class LengowOrder extends Order
 
         try {
             $result = Db::getInstance()->getRow($query);
-        } catch (\PrestaShopDatabaseException $e) {
+        } catch (PrestaShopDatabaseException $e) {
             return false;
         }
         if ($result) {

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -174,7 +174,9 @@ echo -e "- Create files checksum : ${VERT}DONE${NORMAL}"
 # remove TMP FOLDER
 remove_directory "$FOLDER_TMP"
 # copy files
-rsync -a --exclude='.DS_Store' "$FOLDER/" "$FOLDER_TMP/"
+rsync -a --exclude='.DS_Store' --exclude='*.py' --exclude='lenwgoCustom.php' --exclude='debug_*.php' --exclude='image-*.png' "$FOLDER/" "$FOLDER_TMP/"
+# remove loose txt files at root (keep license.txt and mails)
+find "$FOLDER_TMP" -maxdepth 1 -name '*.txt' ! -name 'license.txt' -delete
 # remove dod
 remove_files "$FOLDER_TMP" "dod.md"
 # remove Readme

--- a/webservice/cron.php
+++ b/webservice/cron.php
@@ -18,14 +18,16 @@
  * @copyright 2017 Lengow SAS
  * @license   http://www.apache.org/licenses/LICENSE-2.0
  */
-$_GET['fc'] = 'module';
-$_GET['module'] = 'lengow';
-$_GET['controller'] = 'cron';
+if (!defined('_PS_VERSION_')) {
+    $_GET['fc'] = 'module';
+    $_GET['module'] = 'lengow';
+    $_GET['controller'] = 'cron';
 
-$index = rtrim((string) $_SERVER['DOCUMENT_ROOT'], '/\\') . '/index.php';
-if (!is_file($index)) {
-    header('HTTP/1.1 500 Internal Server Error');
-    exit('Unable to dispatch Lengow front controller');
+    $index = rtrim((string) $_SERVER['DOCUMENT_ROOT'], '/\\') . '/index.php';
+    if (!is_file($index)) {
+        header('HTTP/1.1 500 Internal Server Error');
+        exit('Unable to dispatch Lengow front controller');
+    }
+
+    require $index;
 }
-
-require $index;

--- a/webservice/export.php
+++ b/webservice/export.php
@@ -18,14 +18,16 @@
  * @copyright 2017 Lengow SAS
  * @license   http://www.apache.org/licenses/LICENSE-2.0
  */
-$_GET['fc'] = 'module';
-$_GET['module'] = 'lengow';
-$_GET['controller'] = 'export';
+if (!defined('_PS_VERSION_')) {
+    $_GET['fc'] = 'module';
+    $_GET['module'] = 'lengow';
+    $_GET['controller'] = 'export';
 
-$index = rtrim((string) $_SERVER['DOCUMENT_ROOT'], '/\\') . '/index.php';
-if (!is_file($index)) {
-    header('HTTP/1.1 500 Internal Server Error');
-    exit('Unable to dispatch Lengow front controller');
+    $index = rtrim((string) $_SERVER['DOCUMENT_ROOT'], '/\\') . '/index.php';
+    if (!is_file($index)) {
+        header('HTTP/1.1 500 Internal Server Error');
+        exit('Unable to dispatch Lengow front controller');
+    }
+
+    require $index;
 }
-
-require $index;

--- a/webservice/toolbox.php
+++ b/webservice/toolbox.php
@@ -18,14 +18,16 @@
  * @copyright 2021 Lengow SAS
  * @license   http://www.apache.org/licenses/LICENSE-2.0
  */
-$_GET['fc'] = 'module';
-$_GET['module'] = 'lengow';
-$_GET['controller'] = 'toolbox';
+if (!defined('_PS_VERSION_')) {
+    $_GET['fc'] = 'module';
+    $_GET['module'] = 'lengow';
+    $_GET['controller'] = 'toolbox';
 
-$index = rtrim((string) $_SERVER['DOCUMENT_ROOT'], '/\\') . '/index.php';
-if (!is_file($index)) {
-    header('HTTP/1.1 500 Internal Server Error');
-    exit('Unable to dispatch Lengow front controller');
+    $index = rtrim((string) $_SERVER['DOCUMENT_ROOT'], '/\\') . '/index.php';
+    if (!is_file($index)) {
+        header('HTTP/1.1 500 Internal Server Error');
+        exit('Unable to dispatch Lengow front controller');
+    }
+
+    require $index;
 }
-
-require $index;


### PR DESCRIPTION
## Summary
- Add `if (!defined('_PS_VERSION_'))` check to webservice entry points (`cron.php`, `toolbox.php`, `export.php`)
- Add `class_exists()` guard for Colissimo external classes after dynamic `include_once`
- Replace `Context::getContext()` with `LengowContext::getContext()` in Colissimo integration
- Apply PrestaShop coding standards: `single_line_throw`, `blank_line_after_opening_tag`, `trailing_comma_in_multiline`, `fully_qualified_strict_types`
- Exclude personal/temp files from builds (`.gitignore` + rsync `--exclude` patterns)
- Fix `export/index.php` missing from build zip

## Test plan
- [x] Submit built zip to PrestaShop Addons validator — no errors/warnings expected
- [x] Verify webservice endpoints still work (cron, toolbox, export)
- [x] Verify Colissimo relay point creation still works on orders with relay delivery
