### PR TITLE
feat: align reviewer assignment

### DIFF
--- a/.github/reviewers.yaml
+++ b/.github/reviewers.yaml
@@ -12,6 +12,8 @@ files:
     - repository-owners
   '.github/**':
     - devops
+  'build/**':
+    - devops
 
 options:
   number_of_reviewers: 2

--- a/.github/workflows/auto-assign-reviewer.yaml
+++ b/.github/workflows/auto-assign-reviewer.yaml
@@ -1,17 +1,22 @@
 name: Auto Request Review
 
 on:
-  - pull_request
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
 
 jobs:
   auto-request-review:
     name: Assign Reviewers
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Request review based on files changes and/or groups the author belongs to
-        uses: necojackarc/auto-request-review@v0.11.0
+        uses: necojackarc/auto-request-review@v0.13.0
         with:
           token: ${{ secrets.AUTO_ASSIGN_REVIEWERS }}
-          config: .github/reviewers.yml
+          config: .github/reviewers.yaml


### PR DESCRIPTION
## What

Align the reviewer assignment configuration with the current cookiecutter template.

- Rename `.github/reviewers.yml` to `.github/reviewers.yaml`.
- Rename `.github/workflows/auto-assign-reviewer.yml` to `.github/workflows/auto-assign-reviewer.yaml`.
- Limit workflow events to opened, reopened, and ready-for-review pull requests.
- Skip draft pull requests.
- Update `actions/checkout` to v6 and `auto-request-review` to v0.13.0.
- Keep E-commerce Plugins as repository owner and Platform for GitHub/build paths.

## Why

Remove the legacy workflow and filename discrepancies so repository ownership can be swept consistently from the canonical reviewer configuration.

## Impact

Reviewer assignment remains inactive for drafts and runs when a pull request is opened, reopened, or marked ready. The workflow now reads `.github/reviewers.yaml`.

## Checks

- Both YAML files parsed successfully.
- Workflow action versions, events, draft guard, and config path match the current template.
- `git diff --check` passed.
- Diff is limited to the two canonical file renames and workflow alignment.
